### PR TITLE
fixed-mobile-view-breadcrumb

### DIFF
--- a/index.ftd
+++ b/index.ftd
@@ -1179,8 +1179,7 @@ $on-click$: toggle $show-section
 
 --- ftd.row:
 width: fill
-padding-vertical: $fpm.space.space-2
-padding-vertical if $current-subsection.title is null: $fpm.space.space-4
+padding-vertical: $fpm.space.space-4
 spacing: 4
 id: selection-container
 
@@ -1216,7 +1215,7 @@ white-space: nowrap
 
 --- ftd.row:
 align: right
-padding-top: $fpm.space.space-2
+padding-vertical: $fpm.space.space-3
 
 --- octicons.triangle-down:
 if: not $show-section 


### PR DESCRIPTION
Fixed the header (breadcrumb) in mobile view (in the case of subsection present and not present)
![header-without-subsection-before](https://user-images.githubusercontent.com/102805262/172560060-9e828d39-6efb-4bd1-8e64-f7a468fbdaa4.png)
![header-without-subsection-now](https://user-images.githubusercontent.com/102805262/172560066-2541c1b9-f985-4a5a-b42c-6a074622e697.png)
![header-with-subsection-before](https://user-images.githubusercontent.com/102805262/172560070-5de3bf70-5e52-4cf9-928a-88704e507d8a.png)
![header-with-subsection-now](https://user-images.githubusercontent.com/102805262/172560074-f3ed8599-bcf0-40d4-874d-8f3d3e510b05.png)
